### PR TITLE
fix(input): fix input type

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react'
 import classNames from 'classnames'
 import { ThemeContext } from './context/ThemeContext'
 
-interface Props extends React.HTMLAttributes<HTMLInputElement> {
+interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
   valid?: boolean
   disabled?: boolean
   type?: string


### PR DESCRIPTION
Hey @estevanmaito,

I noticed that typescript wasn't allowing me to pass down input specific properties to the Input component. I took a look and the Input props extends from HTMLAttributes. This small PR changes the Input props to extend from InputHTMLAttributes instead.

Hope this helps 🙂