### PR TITLE
Feat/custom button layouts

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -33,7 +33,7 @@ export interface Props {
   /**
    * The style of the button
    */
-  layout?: 'outline' | 'link' | 'primary' | '__dropdownItem'
+  layout?: 'outline' | 'link' | 'primary' | '__dropdownItem' | string
   /**
    * Shows the button as a block (full width)
    */
@@ -121,16 +121,19 @@ const Button = React.forwardRef<Ref, ButtonProps>(function Button(props, ref) {
     primary: button.primary.base,
     outline: button.outline.base,
     link: button.link.base,
+    [layout]: button[layout]?.base,
   }
   const activeStyles = {
     primary: button.primary.active,
     outline: button.outline.active,
     link: button.link.active,
+    [layout]: button[layout]?.active,
   }
   const disabledStyles = {
     primary: button.primary.disabled,
     outline: button.outline.disabled,
     link: button.link.disabled,
+    [layout]: button[layout]?.disabled,
   }
 
   /**

--- a/src/__tests__/Button.test.tsx
+++ b/src/__tests__/Button.test.tsx
@@ -165,6 +165,30 @@ describe('Primary Button', () => {
   })
 })
 
+describe('Custom Button', () => {
+  it('should contain custom base classes', () => {
+    const expected = 'text-pink-600 dark:text-pink-400'
+    const wrapper = mount(<Button aria-label="test" layout="custom" />)
+
+    expect(wrapper.find('button').getDOMNode().getAttribute('class')).toContain(expected)
+  })
+
+  it('should contain custom active classes', () => {
+    const expected =
+      'active:bg-transparent hover:bg-pink-100 dark:hover:bg-pink-500 dark:hover:text-pink-300'
+    const wrapper = mount(<Button aria-label="test" layout="custom" />)
+
+    expect(wrapper.find('button').getDOMNode().getAttribute('class')).toContain(expected)
+  })
+
+  it('should contain custom disabled classes', () => {
+    const expected = 'opacity-50 cursor-not-allowed bg-pink-300'
+    const wrapper = mount(<Button aria-label="test" layout="custom" disabled />)
+
+    expect(wrapper.find('button[disabled]').getDOMNode().getAttribute('class')).toContain(expected)
+  })
+})
+
 describe('Outline Button', () => {
   it('should contain outline base classes', () => {
     const expected = 'text-gray-600 border-gray-300 border dark:text-gray-400 focus:outline-none'

--- a/src/themes/default.ts
+++ b/src/themes/default.ts
@@ -208,6 +208,12 @@ export default {
         'active:bg-transparent hover:bg-gray-100 focus:shadow-outline-gray dark:hover:bg-gray-500 dark:hover:text-gray-300 dark:hover:bg-opacity-10',
       disabled: 'opacity-50 cursor-not-allowed',
     },
+    custom: {
+      base: 'text-pink-600 dark:text-pink-400',
+      active:
+        'active:bg-transparent hover:bg-pink-100 dark:hover:bg-pink-500 dark:hover:text-pink-300',
+      disabled: 'opacity-50 cursor-not-allowed bg-pink-300',
+    },
     // this is the button that lives inside the DropdownItem
     dropdownItem: {
       base:


### PR DESCRIPTION
This allows the layout prop to be dynamic based on whatever config a developer overwrites in the for theme.

If you have plans to implement this in a different way for custom themes let me know and I would love to collab to help extend the custom theme configs.