### PR TITLE
fix(package.json): add tailwind build before run storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint:fix": "eslint . --fix",
     "prerelease": "npm run build",
     "release": "release-it",
+    "prestorybook": "npm run build:tailwind",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },


### PR DESCRIPTION
I added the tailwind build before the storybook task.
In this way, we can generate the `output.css` file and then run storybook. 